### PR TITLE
[Feat/#3] : 카카오 지도 API 구현

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -31,6 +31,7 @@
       crossorigin="anonymous"
       referrerpolicy="no-referrer"
     />
+    <script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=cc86c8bb23f02bb5a866b26a78e255db&libraries=services,clusterer"></script>
     <title>React App</title>
   </head>
   <body>

--- a/frontend/src/components/KakaoMap.js
+++ b/frontend/src/components/KakaoMap.js
@@ -1,0 +1,88 @@
+import '../components/KakaoMapStyles.css';
+import { useEffect, useState } from "react";
+import { Map, MapMarker } from "react-kakao-maps-sdk"
+
+function KakaoMap() {
+const {kakao} = window;
+    const [info, setInfo] = useState()
+  const [markers, setMarkers] = useState([])
+  const [map, setMap] = useState()
+  const [searchInputValue, setSearchInputValue] = useState("");
+const [keyword, setKeyword] = useState("");
+
+  useEffect(() => {
+    if (!map) return
+    const ps = new kakao.maps.services.Places()
+
+    ps.keywordSearch(keyword, (data, status, _pkagination) => {
+      if (status === kakao.maps.services.Status.OK) {
+        // 검색된 장소 위치를 기준으로 지도 범위를 재설정하기위해
+        // LatLngBounds 객체에 좌표를 추가합니다
+        const bounds = new kakao.maps.LatLngBounds()
+        let markers = []
+
+        for (var i = 0; i < data.length; i++) {
+          // @ts-ignore
+          markers.push({
+            position: {
+              lat: data[i].y,
+              lng: data[i].x,
+            },
+            content: data[i].place_name,
+          })
+          // @ts-ignore
+          bounds.extend(new kakao.maps.LatLng(data[i].y, data[i].x))
+        }
+        setMarkers(markers)
+
+        // 검색된 장소 위치를 기준으로 지도 범위를 재설정합니다
+        map.setBounds(bounds)
+      }
+    })
+  }, [map, keyword])
+
+  const handleKeyPress = (e) => {
+    if (e.key === "Enter") setKeyword(searchInputValue);
+  };
+
+  return (
+    <div className="kakao-map">
+    <input
+    	onChange={(e) => setSearchInputValue(e.target.value)}
+        onKeyPress={(e) => handleKeyPress(e)}
+        value={searchInputValue}
+        placeholder={"장소를 입력해주세요 ex)서울특별시 역삼동 or 경복궁"}
+        className='kakao-input'
+    />
+    <button onClick={() => setKeyword(searchInputValue)}>
+      검색
+    </button>
+    <Map // 로드뷰를 표시할 Container
+      center={{
+        lat: 37.566826,
+        lng: 126.9786567,
+      }}
+      style={{
+        width: "100%",
+        height: "350px",
+      }}
+      level={3}
+      onCreate={setMap}
+    >
+      {markers.map((marker) => (
+        <MapMarker
+          key={`marker-${marker.content}-${marker.position.lat},${marker.position.lng}`}
+          position={marker.position}
+          onClick={() => setInfo(marker)}
+        >
+          {info &&info.content === marker.content && (
+            <div style={{color:"#000"}}>{marker.content}</div>
+          )}
+        </MapMarker>
+      ))}
+    </Map>
+    </div>
+  )
+}
+
+export default KakaoMap;

--- a/frontend/src/components/KakaoMapStyles.css
+++ b/frontend/src/components/KakaoMapStyles.css
@@ -1,0 +1,19 @@
+.kakao-map {
+    margin: 4rem 6rem;
+}
+
+.kakao-input {
+    width: 40%;
+    padding: 0.5rem 1rem;
+    font-size: 1rem;
+    font-weight: 600;
+    margin-bottom: 1rem;
+    margin-right: 1rem;
+}
+
+@media screen and (max-width: 850px) {
+    .kakao-map {
+      margin: 4rem 2rem;
+    }
+  }
+  

--- a/frontend/src/components/Trip.js
+++ b/frontend/src/components/Trip.js
@@ -3,12 +3,15 @@ import TripData from './TripData';
 import Trip1 from '../assets/7.png';
 import Trip2 from '../assets/8.png';
 import Trip3 from '../assets/9.png';
+import KakaoMap from './KakaoMap';
+
 
 function Trip() {
   return (
     <div className="trip">
       <h1>Recent Trips</h1>
-      <p>You can discover unique destinations using Google Maps.</p>
+      <p>You can discover unique destinations using Kakao Maps.</p>
+      <KakaoMap/>
       <div className="tripcard">
         <TripData
           image={Trip1}

--- a/frontend/src/routes/Service.js
+++ b/frontend/src/routes/Service.js
@@ -3,6 +3,7 @@ import Hero from '../components/Hero';
 import AboutImg from '../assets/service.jpg';
 import Footer from '../components/Footer';
 import Trip from '../components/Trip';
+import KakaoMap from '../components/KakaoMap';
 
 function Service() {
   return (
@@ -15,6 +16,7 @@ function Service() {
         btnClass="hide"
       />
       <Trip />
+      <KakaoMap/>
       <Footer />
     </>
   );

--- a/frontend/src/routes/Service.js
+++ b/frontend/src/routes/Service.js
@@ -3,7 +3,6 @@ import Hero from '../components/Hero';
 import AboutImg from '../assets/service.jpg';
 import Footer from '../components/Footer';
 import Trip from '../components/Trip';
-import KakaoMap from '../components/KakaoMap';
 
 function Service() {
   return (
@@ -16,7 +15,7 @@ function Service() {
         btnClass="hide"
       />
       <Trip />
-      <KakaoMap/>
+      
       <Footer />
     </>
   );


### PR DESCRIPTION
## 📌 관련 이슈
#3 

## ✨ 코드 변경 내용
- npm 명령어
(npm install react-kakao-maps-sdk)
-카카오 지도 API
(카카오 키워드 검색기능 구현)
(index.html에 카카오 API key 들어있음)
-카카오 지도 스타일 시트

## 📸 스크린샷(선택)
검색 전 마커 없는 version
<img width="1131" alt="image" src="https://github.com/Webserver-Programming/Webserver-frontend/assets/155093974/8ace05cf-f9df-492a-972b-66b57f7f1f1d">

검색 후 마커 있는 version
<img width="1137" alt="image" src="https://github.com/Webserver-Programming/Webserver-frontend/assets/155093974/ad8ff6c1-e57e-4f50-ab3d-626046ac186d">


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들